### PR TITLE
Allow non-strings as query parameters with pager.

### DIFF
--- a/src/Pager.php
+++ b/src/Pager.php
@@ -52,14 +52,9 @@ class Pager extends \ArrayObject
         } else {
             unset($parameters['page']);
         }
-        array_walk(
-            $parameters,
-            function (&$item, $key) {
-                $item = "$key=$item";
-            }
-        );
-        $parameters[] = $pageid . '=';
-        $link = '?' . implode('&', $parameters);
+
+        $parameters[$pageid] = '';
+        $link = '?' . http_build_query($parameters);
 
         return $link;
     }


### PR DESCRIPTION
Pager doesn't work with array as query parameter. This issue is solved with help of http_build_query().
